### PR TITLE
fix(vite): allow upperglam hosts in preview

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,4 +12,7 @@ export default defineConfig({
       },
     }),
   ],
+  preview: {
+    allowedHosts: ['upperglam.fr', 'www.upperglam.fr'],
+  },
 })


### PR DESCRIPTION
## Summary
- add `preview.allowedHosts` in `vite.config.ts`
- allow both `upperglam.fr` and `www.upperglam.fr`

## Why
Vite preview was blocking requests from `www.upperglam.fr` in production.

## Verification
- `npm run build` passes locally