### PR TITLE
fix(analytics): enforce strict opt-in tracking

### DIFF
--- a/src/app/RootApp.tsx
+++ b/src/app/RootApp.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { PostHogProvider } from 'posthog-js/react'
+import { App } from './App'
+import {
+  ANALYTICS_CONSENT_CHANGED_EVENT,
+  getAnalyticsConsentStatus,
+  posthogOptions,
+} from '../lib/analytics'
+
+type RootAppProps = {
+  posthogKey?: string
+}
+
+export function RootApp({ posthogKey }: RootAppProps) {
+  const [consentStatus, setConsentStatus] = useState(getAnalyticsConsentStatus)
+
+  useEffect(() => {
+    const syncConsent = () => {
+      setConsentStatus(getAnalyticsConsentStatus())
+    }
+
+    window.addEventListener(ANALYTICS_CONSENT_CHANGED_EVENT, syncConsent)
+    window.addEventListener('storage', syncConsent)
+
+    return () => {
+      window.removeEventListener(ANALYTICS_CONSENT_CHANGED_EVENT, syncConsent)
+      window.removeEventListener('storage', syncConsent)
+    }
+  }, [])
+
+  if (!posthogKey || consentStatus !== 'accepted') return <App />
+
+  return (
+    <PostHogProvider apiKey={posthogKey} options={posthogOptions}>
+      <App />
+    </PostHogProvider>
+  )
+}

--- a/src/components/common/CookieBanner.tsx
+++ b/src/components/common/CookieBanner.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react'
-import { trackEvent } from '../../lib/analytics'
+import {
+  ANALYTICS_CONSENT_STORAGE_KEY,
+  setAnalyticsConsentStatus,
+  trackEvent,
+} from '../../lib/analytics'
 import { Button } from '../ui/Button'
 import { Container } from '../layout/Container'
 
-const STORAGE_KEY = 'ug_cookie_consent'
-
 export function CookieBanner() {
   const [visible, setVisible] = useState(() => {
-    const consent = window.localStorage.getItem(STORAGE_KEY)
+    const consent = window.localStorage.getItem(ANALYTICS_CONSENT_STORAGE_KEY)
     return !consent
   })
 
@@ -23,7 +25,7 @@ export function CookieBanner() {
         <div className="flex gap-2">
           <Button
             onClick={() => {
-              window.localStorage.setItem(STORAGE_KEY, 'accepted')
+              setAnalyticsConsentStatus('accepted')
               trackEvent('cookie_consent_updated', { status: 'accepted' })
               setVisible(false)
             }}
@@ -34,8 +36,7 @@ export function CookieBanner() {
           </Button>
           <Button
             onClick={() => {
-              window.localStorage.setItem(STORAGE_KEY, 'refused')
-              trackEvent('cookie_consent_updated', { status: 'refused' })
+              setAnalyticsConsentStatus('refused')
               setVisible(false)
             }}
             size="md"

--- a/src/components/common/PostHogPageView.tsx
+++ b/src/components/common/PostHogPageView.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
-import posthog from 'posthog-js'
 import { useLocation, useNavigationType } from 'react-router-dom'
-import { trackEvent } from '../../lib/analytics'
+import { trackPageView } from '../../lib/analytics'
 
 export function PostHogPageView() {
   const location = useLocation()
@@ -15,8 +14,7 @@ export function PostHogPageView() {
       url: window.location.href,
     }
 
-    posthog.capture('$pageview', pageViewProperties)
-    trackEvent('page_view', pageViewProperties)
+    trackPageView(pageViewProperties)
   }, [location.pathname, location.search, navigationType])
 
   return null

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -9,6 +9,11 @@ export const posthogOptions: Partial<PostHogConfig> = {
   person_profiles: 'identified_only',
 }
 
+export const ANALYTICS_CONSENT_STORAGE_KEY = 'ug_cookie_consent'
+export const ANALYTICS_CONSENT_CHANGED_EVENT = 'ug-cookie-consent-changed'
+
+export type AnalyticsConsentStatus = 'accepted' | 'refused'
+
 export type AnalyticsEventName =
   | 'cookie_consent_updated'
   | 'cta_click'
@@ -20,9 +25,44 @@ export type AnalyticsEventName =
   | 'page_view'
   | 'pre_signup_role_selected'
 
+export function getAnalyticsConsentStatus(): AnalyticsConsentStatus | null {
+  if (typeof window === 'undefined') return null
+
+  const consent = window.localStorage.getItem(ANALYTICS_CONSENT_STORAGE_KEY)
+  if (consent === 'accepted' || consent === 'refused') return consent
+
+  return null
+}
+
+export function hasAnalyticsConsent(): boolean {
+  return getAnalyticsConsentStatus() === 'accepted'
+}
+
+export function setAnalyticsConsentStatus(status: AnalyticsConsentStatus) {
+  if (typeof window === 'undefined') return
+
+  window.localStorage.setItem(ANALYTICS_CONSENT_STORAGE_KEY, status)
+  window.dispatchEvent(
+    new CustomEvent(ANALYTICS_CONSENT_CHANGED_EVENT, {
+      detail: { status },
+    })
+  )
+}
+
 export function trackEvent(
   event: AnalyticsEventName,
   properties?: Record<string, string | number | boolean | null | undefined>
 ) {
+  if (!hasAnalyticsConsent()) return
+
   posthog.capture(event, properties)
+}
+
+export function trackPageView(
+  properties: Record<string, string | number | boolean | null | undefined>
+) {
+  if (!hasAnalyticsConsent()) return
+
+  posthog.capture('$pageview', properties)
+  trackEvent('page_view', properties)
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { PostHogProvider } from 'posthog-js/react'
-import { App } from './app/App'
-import { posthogOptions } from './lib/analytics'
+import { RootApp } from './app/RootApp'
 import './styles/globals.css'
 
 const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {posthogKey ? (
-      <PostHogProvider apiKey={posthogKey} options={posthogOptions}>
-        <App />
-      </PostHogProvider>
-    ) : (
-      <App />
-    )}
+    <RootApp posthogKey={posthogKey} />
   </StrictMode>
 )


### PR DESCRIPTION
## Summary
This PR implements **Group 1** of the marketing TODO by enforcing strict analytics opt-in.

### What changed
- Gate PostHog provider initialization behind explicit consent (`accepted` only).
- Centralize consent state/helpers in `src/lib/analytics.ts`.
- Block all tracking calls when consent is not accepted.
- Route pageview tracking through consent-gated helpers.
- Update cookie banner to use shared consent helpers and dispatch consent updates.

### Files
- `src/app/RootApp.tsx`
- `src/main.tsx`
- `src/lib/analytics.ts`
- `src/components/common/CookieBanner.tsx`
- `src/components/common/PostHogPageView.tsx`

## Validation
- `npm run lint` ✅
- `npm run build` ✅

Closes #10