### PR TITLE
fix(consent): add cookie preferences management

### DIFF
--- a/src/components/common/CookieBanner.tsx
+++ b/src/components/common/CookieBanner.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
-  ANALYTICS_CONSENT_STORAGE_KEY,
+  ANALYTICS_CONSENT_CHANGED_EVENT,
+  COOKIE_PREFERENCES_OPEN_EVENT,
+  getAnalyticsConsentStatus,
   setAnalyticsConsentStatus,
   trackEvent,
 } from '../../lib/analytics'
@@ -8,42 +10,90 @@ import { Button } from '../ui/Button'
 import { Container } from '../layout/Container'
 
 export function CookieBanner() {
-  const [visible, setVisible] = useState(() => {
-    const consent = window.localStorage.getItem(ANALYTICS_CONSENT_STORAGE_KEY)
-    return !consent
-  })
+  const [consentStatus, setConsentStatus] = useState(getAnalyticsConsentStatus)
+  const [visible, setVisible] = useState(() => !getAnalyticsConsentStatus())
+
+  useEffect(() => {
+    const syncConsent = () => {
+      const nextStatus = getAnalyticsConsentStatus()
+      setConsentStatus(nextStatus)
+      if (!nextStatus) setVisible(true)
+    }
+
+    const openPreferences = () => {
+      setConsentStatus(getAnalyticsConsentStatus())
+      setVisible(true)
+    }
+
+    window.addEventListener(ANALYTICS_CONSENT_CHANGED_EVENT, syncConsent)
+    window.addEventListener(COOKIE_PREFERENCES_OPEN_EVENT, openPreferences)
+    window.addEventListener('storage', syncConsent)
+
+    return () => {
+      window.removeEventListener(ANALYTICS_CONSENT_CHANGED_EVENT, syncConsent)
+      window.removeEventListener(COOKIE_PREFERENCES_OPEN_EVENT, openPreferences)
+      window.removeEventListener('storage', syncConsent)
+    }
+  }, [])
 
   if (!visible) return null
+
+  const isFirstChoice = !consentStatus
+
+  const closeBanner = () => {
+    if (isFirstChoice) return
+    setVisible(false)
+  }
 
   return (
     <div className="fixed right-0 bottom-0 left-0 z-40 border-t border-[var(--ug-border)] bg-[color:var(--ug-banner-bg)] py-4">
       <Container className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
-        <p className="text-sm text-[var(--ug-muted)]">
-          Nous utilisons des cookies essentiels. Le tracking analytique sera
-          active uniquement avec votre accord.
-        </p>
-        <div className="flex gap-2">
-          <Button
-            onClick={() => {
-              setAnalyticsConsentStatus('accepted')
-              trackEvent('cookie_consent_updated', { status: 'accepted' })
-              setVisible(false)
-            }}
-            size="md"
-            variant="primary"
-          >
-            Accepter
-          </Button>
-          <Button
-            onClick={() => {
-              setAnalyticsConsentStatus('refused')
-              setVisible(false)
-            }}
-            size="md"
-            variant="secondary"
-          >
-            Refuser
-          </Button>
+        <div className="space-y-1">
+          <p className="text-sm text-[var(--ug-muted)]">
+            Nous utilisons des cookies essentiels. Le tracking analytique reste
+            desactive tant que vous n'acceptez pas.
+          </p>
+          {!isFirstChoice && (
+            <p className="text-xs text-[var(--ug-muted)]">
+              Statut actuel :{' '}
+              {consentStatus === 'accepted'
+                ? 'analytics actif'
+                : 'analytics inactif'}
+              .
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {consentStatus !== 'accepted' && (
+            <Button
+              onClick={() => {
+                setAnalyticsConsentStatus('accepted')
+                trackEvent('cookie_consent_updated', { status: 'accepted' })
+                setVisible(false)
+              }}
+              size="md"
+              variant="primary"
+            >
+              Accepter
+            </Button>
+          )}
+          {consentStatus !== 'refused' && (
+            <Button
+              onClick={() => {
+                setAnalyticsConsentStatus('refused')
+                setVisible(false)
+              }}
+              size="md"
+              variant="secondary"
+            >
+              Refuser
+            </Button>
+          )}
+          {!isFirstChoice && (
+            <Button onClick={closeBanner} size="md" variant="secondary">
+              Fermer
+            </Button>
+          )}
         </div>
       </Container>
     </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { siteCopy } from '../../content/copy'
-import { trackEvent } from '../../lib/analytics'
+import { openCookiePreferences, trackEvent } from '../../lib/analytics'
 import { Container } from './Container'
 
 const footerLinks = [
@@ -46,6 +46,20 @@ export function Footer() {
                   {item.label}
                 </Link>
               ))}
+              <button
+                className="block cursor-pointer text-left hover:text-[var(--ug-accent)]"
+                onClick={() => {
+                  openCookiePreferences()
+                  trackEvent('legal_link_click', {
+                    label: 'Gerer mes cookies',
+                    location: 'footer',
+                    to: 'cookie_preferences',
+                  })
+                }}
+                type="button"
+              >
+                Gerer mes cookies
+              </button>
             </div>
             <div className="space-y-2">
               <p className="text-xs font-semibold tracking-[0.1em] text-[var(--ug-text)] uppercase">

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,6 +11,7 @@ export const posthogOptions: Partial<PostHogConfig> = {
 
 export const ANALYTICS_CONSENT_STORAGE_KEY = 'ug_cookie_consent'
 export const ANALYTICS_CONSENT_CHANGED_EVENT = 'ug-cookie-consent-changed'
+export const COOKIE_PREFERENCES_OPEN_EVENT = 'ug-cookie-preferences-open'
 
 export type AnalyticsConsentStatus = 'accepted' | 'refused'
 
@@ -47,6 +48,12 @@ export function setAnalyticsConsentStatus(status: AnalyticsConsentStatus) {
       detail: { status },
     })
   )
+}
+
+export function openCookiePreferences() {
+  if (typeof window === 'undefined') return
+
+  window.dispatchEvent(new Event(COOKIE_PREFERENCES_OPEN_EVENT))
 }
 
 export function trackEvent(


### PR DESCRIPTION
## Summary
This PR implements **Group 2** of the marketing/admin plan (cookie consent management).

### What changed
- Added a global "Gerer mes cookies" entry in footer.
- Added a dedicated app event to open cookie preferences from anywhere.
- Upgraded cookie banner behavior to support:
  - first consent choice,
  - post-accept consent withdrawal,
  - explicit close in management mode,
  - state sync with localStorage and cross-tab updates.
- Kept analytics behavior consistent with strict opt-in.

### Files
- `src/lib/analytics.ts`
- `src/components/common/CookieBanner.tsx`
- `src/components/layout/Footer.tsx`

## Validation
- `npm run lint` ✅
- `npm run build` ✅

Closes #11