### PR TITLE
fix(analytics): harden posthog pre-signup tracking

### DIFF
--- a/pre_inscription_and_back_office_tasks.md
+++ b/pre_inscription_and_back_office_tasks.md
@@ -1,0 +1,86 @@
+# Plan de livraison - pré-inscription, PostHog et back-office
+
+Principe : chaque lot est terminé, vérifié, puis livré par **commit → pull request → merge dans `main`** avant de commencer le suivant.
+
+## État initial déjà livré
+
+- [x] Regrouper les pré-inscriptions particulier et professionnel sur une page dynamique.
+- [x] Aligner les formulaires sur le contrat API documenté dans `ressources`.
+- [x] Réinitialiser le formulaire et afficher un succès après un `201 Created`.
+- [x] Rediriger les anciennes routes vers `/pre-inscription`.
+- [x] Créer la connexion, la protection de routes et la gestion des pré-inscriptions du back-office.
+- [x] Exclure les routes `/admin` du tracking PostHog.
+- [x] Mettre en place les protections de `main`, les conventions de commit et la CI.
+
+## Lot 1 — Fiabiliser le socle analytics et la feuille de route
+
+Objectif : garantir un tracking exploitable, respectueux du consentement et sans données du back-office.
+
+- [x] Auditer le projet PostHog connecté via MCP.
+- [x] Comparer les événements du code, le schéma reçu, les actions et les dashboards PostHog.
+- [x] Bloquer tous les événements PostHog dont l'URL commence par `/admin`, y compris l'autocapture et les événements techniques.
+- [x] Désactiver explicitement les enregistrements de session.
+- [x] Tracer les tentatives, succès et erreurs de pré-inscription sans donnée personnelle.
+- [x] Vérifier les tests, le lint, le formatage des fichiers modifiés et le build du lot.
+- [ ] Vérifier dans l'environnement déployé que `VITE_PUBLIC_POSTHOG_KEY` cible bien le projet PostHog `130601`.
+- [ ] Faire un test réel avec consentement accepté et confirmer la réception des événements dans PostHog.
+- [ ] Confirmer qu'aucun événement `/admin` n'est reçu.
+
+Constat MCP du 8 juillet 2026 : le projet est accessible et a reçu des événements historiques, mais aucun événement depuis mai 2026. Les nouveaux événements de pré-inscription ne sont donc pas encore observables côté PostHog.
+
+## Lot 2 — Couvrir le funnel de pré-inscription dans PostHog
+
+Prérequis : le lot 1 est mergé et les événements sont visibles dans PostHog.
+
+- [ ] Documenter la taxonomie des événements et propriétés non sensibles.
+- [ ] Ajouter ou mettre à jour les actions PostHog pour : choix du profil, tentative, succès et erreur.
+- [ ] Remplacer l'ancien funnel `pageview → CTA → contact` par les funnels :
+  - [ ] `pageview → CTA pré-inscription → choix du profil → tentative → succès` pour les particuliers ;
+  - [ ] le même funnel pour les professionnels.
+- [ ] Ajouter les taux d'erreur par profil et type d'erreur.
+- [ ] Ajouter la conversion par page d'entrée, CTA, source UTM, appareil et navigateur.
+- [ ] Ajouter un suivi du consentement accepté sans tenter de mesurer les refus avant consentement.
+- [ ] Mettre à jour les dashboards `UG - Marketing Conversion` et `UG - Engagement & Trust`.
+- [ ] Vérifier que chaque insight retourne des données cohérentes.
+
+## Lot 3 — Valider la pré-inscription de bout en bout
+
+- [ ] Tester une pré-inscription particulier contre l'API réelle.
+- [ ] Tester une pré-inscription professionnel contre l'API réelle.
+- [ ] Vérifier le succès après `201 Created` et la remise à zéro du formulaire.
+- [ ] Vérifier les erreurs de validation, API et réseau.
+- [ ] Vérifier les doublons et les soumissions répétées.
+- [ ] Vérifier le comportement mobile et l'accessibilité clavier.
+- [ ] Vérifier que les anciennes routes ne sont plus référencées.
+- [ ] Ajouter les tests manquants sur les erreurs et doubles soumissions.
+
+## Lot 4 — Valider et durcir le back-office
+
+- [ ] Tester la connexion avec un admin et le refus d'un compte non-admin.
+- [ ] Vérifier la persistance, l'expiration et la déconnexion de session.
+- [ ] Tester la liste et toutes les actions de gestion des pré-inscriptions.
+- [ ] Vérifier les états vide, chargement et erreur.
+- [ ] Ajouter une confirmation avant toute action sensible.
+- [ ] Ajouter des notifications de succès et d'échec.
+- [ ] Vérifier le responsive et l'accessibilité du back-office.
+- [ ] Ajouter les tests manquants sur les parcours critiques.
+
+## Lot 5 — Améliorer la gestion des pré-inscriptions
+
+- [ ] Ajouter une pagination lorsque le volume le justifie.
+- [ ] Ajouter une recherche par email, nom et type de profil.
+- [ ] Ajouter des filtres par statut.
+- [ ] Ajouter une page de détail si les informations ne tiennent plus dans la liste.
+- [ ] Améliorer la gestion des erreurs d'authentification.
+
+## Lot 6 — Maintenance du dépôt
+
+- [ ] Corriger les fichiers historiques signalés par `npm run format:check`.
+- [ ] Vérifier `npm run workflow:check` localement.
+- [ ] Vérifier les checks GitHub Actions sur une pull request.
+- [ ] Vérifier que les protections de branche restent compatibles avec un mainteneur unique.
+- [ ] Ajouter un template de pull request et des templates d'issues.
+- [ ] Ajouter `CONTRIBUTING.md` et documenter les conventions de commit.
+- [ ] Ajouter Dependabot et un audit de sécurité npm.
+- [ ] Ajouter un badge CI au `README.md`.
+- [ ] Ajouter `CODEOWNERS` seulement lorsque plusieurs contributeurs réguliers rejoignent le projet.

--- a/src/components/pre-signup/PreSignupForm.test.tsx
+++ b/src/components/pre-signup/PreSignupForm.test.tsx
@@ -75,6 +75,7 @@ describe('PreSignupForm critical flow', () => {
     await waitFor(() => {
       expect(trackEventMock).toHaveBeenCalledWith('form_submit', {
         form_name: 'pre_signup_client',
+        marketing_opt_in: false,
         role: 'user',
       })
     })

--- a/src/components/pre-signup/PreSignupForm.tsx
+++ b/src/components/pre-signup/PreSignupForm.tsx
@@ -94,9 +94,10 @@ export function PreSignupForm({
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    const form = event.currentTarget
     setLocalError(null)
     setSuccessMessage(null)
-    const formData = new FormData(event.currentTarget)
+    const formData = new FormData(form)
     const interest = getTrimmedValue(formData, 'interest')
     const comment = getTrimmedValue(formData, 'comment')
     const firstName = getTrimmedValue(formData, 'firstName')
@@ -122,12 +123,29 @@ export function PreSignupForm({
     )
     const marketingOptIn = formData.get('marketingOptIn') === 'on'
 
+    trackEvent('form_submit_attempt', {
+      form_name: trackingFormName,
+      role,
+    })
+
     if (!firstName || !lastName) {
+      trackEvent('form_submit_error', {
+        error_type: 'client_validation',
+        field: 'identity',
+        form_name: trackingFormName,
+        role,
+      })
       setLocalError('Le prenom et le nom sont obligatoires.')
       return
     }
 
     if (role === 'provider' && !displayName) {
+      trackEvent('form_submit_error', {
+        error_type: 'client_validation',
+        field: 'provider_display_name',
+        form_name: trackingFormName,
+        role,
+      })
       setLocalError('Le nom public est obligatoire pour un prestataire.')
       return
     }
@@ -171,11 +189,17 @@ export function PreSignupForm({
       })
       trackEvent('form_submit', {
         form_name: trackingFormName,
+        marketing_opt_in: marketingOptIn,
         role,
       })
-      event.currentTarget.reset()
+      form.reset()
       setSuccessMessage('Pre-inscription envoyee avec succes.')
     } catch {
+      trackEvent('form_submit_error', {
+        error_type: 'api_or_network',
+        form_name: trackingFormName,
+        role,
+      })
       setSuccessMessage(null)
     }
   }

--- a/src/lib/analytics.consent.test.ts
+++ b/src/lib/analytics.consent.test.ts
@@ -15,6 +15,7 @@ import {
   setAnalyticsConsentStatus,
   trackEvent,
   trackPageView,
+  posthogOptions,
 } from './analytics'
 
 describe('analytics consent gating', () => {
@@ -103,5 +104,17 @@ describe('analytics consent gating', () => {
     })
 
     expect(captureMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops every event emitted from an admin route', () => {
+    const beforeSend = posthogOptions.before_send
+    const filter = Array.isArray(beforeSend) ? beforeSend[0] : beforeSend
+    const event = {
+      event: '$autocapture',
+      properties: { $current_url: 'https://upperglam.fr/admin/login' },
+      uuid: 'event-id',
+    }
+
+    expect(filter?.(event)).toBeNull()
   })
 })

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -4,8 +4,19 @@ import type { PostHogConfig } from 'posthog-js'
 export const posthogOptions: Partial<PostHogConfig> = {
   api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
   autocapture: true,
+  before_send: (event) => {
+    if (!event) return null
+
+    const eventUrl = String(event.properties?.$current_url ?? '')
+    const pathname = eventUrl
+      ? new URL(eventUrl, window.location.origin).pathname
+      : window.location.pathname
+
+    return pathname.startsWith('/admin') ? null : event
+  },
   capture_pageleave: true,
   capture_pageview: false,
+  disable_session_recording: true,
   person_profiles: 'identified_only',
 }
 
@@ -20,6 +31,8 @@ export type AnalyticsEventName =
   | 'cta_click'
   | 'faq_item_toggle'
   | 'form_submit'
+  | 'form_submit_attempt'
+  | 'form_submit_error'
   | 'legal_link_click'
   | 'nav_click'
   | 'outbound_click'


### PR DESCRIPTION
## Summary

Fiabilise le socle analytics PostHog pour la pré-inscription.

- bloque les événements PostHog provenant des routes `/admin`, y compris autocapture et événements techniques ;
- désactive explicitement les session recordings côté configuration frontend ;
- ajoute le tracking non sensible des tentatives, succès et erreurs de pré-inscription ;
- ajoute le plan de livraison par lots pour pré-inscription, PostHog et back-office.

## Checklist

- [x] PR title follows semantic convention (`feat:`, `fix:`, `chore:`, etc.)
- [x] Source branch name follows `type/description` (example: `fix/login-error-message`)
- [ ] `npm run workflow:check` passes locally
- [x] UX impact has been tested on mobile if UI changed

## Validation

- [x] `npm run test` — 8 files, 17 tests passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] Prettier targeted check on modified files

`npm run workflow:check` does not pass locally because the global `format:check` reports pre-existing formatting issues outside this Lot 1 scope, including historical test/config/docs files. The modified files pass targeted Prettier. The cleanup is tracked separately in Lot 6.

## Related

- Issue: #
