### PR TITLE
feat(analytics): add posthog pre-signup funnel

### DIFF
--- a/docs/posthog-pre-signup-taxonomy.md
+++ b/docs/posthog-pre-signup-taxonomy.md
@@ -1,0 +1,56 @@
+# Taxonomie PostHog - funnel de pré-inscription
+
+Objectif : suivre le funnel de pré-inscription sans envoyer de donnée personnelle.
+
+## Règles générales
+
+- Les événements sont envoyés uniquement après consentement analytics.
+- Les routes `/admin` sont exclues par `before_send`.
+- Les enregistrements de session sont désactivés côté frontend.
+- Ne jamais envoyer : email, téléphone, nom, prénom, ville, code postal, message libre, mot de passe.
+- Tous les événements frontend sont enrichis automatiquement avec :
+  - `current_path`, `current_search`, `current_url` ;
+  - `entry_path`, `entry_search`, `initial_referrer` ;
+  - `referrer` ;
+  - `traffic_source` ;
+  - `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term` lorsqu'ils existent.
+
+## Événements du funnel
+
+| Étape                | Event PostHog              | Propriétés clés                                                                                                                                   | Notes                                                                                       |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Vue de page          | `$pageview` et `page_view` | `pathname`, `search`, `url`                                                                                                                       | `page_view` sert aux dashboards custom ; `$pageview` garde la compatibilité PostHog native. |
+| CTA pré-inscription  | `cta_click`                | `funnel_name=pre_signup`, `funnel_step=cta_click`, `cta`, `location`, `to`, `target_role` si connu                                                | Inclut les CTA client, pro et header.                                                       |
+| Choix du profil      | `pre_signup_role_selected` | `funnel_name=pre_signup`, `funnel_step=role_selected`, `role`, `form_name`                                                                        | `role=user` pour particulier, `role=provider` pour professionnel.                           |
+| Tentative formulaire | `form_submit_attempt`      | `funnel_name=pre_signup`, `funnel_step=submit_attempt`, `role`, `form_name`, `source=marketing_website`                                           | Déclenché avant validation JS métier, hors validation HTML native.                          |
+| Succès formulaire    | `form_submit`              | `funnel_name=pre_signup`, `funnel_step=submit_success`, `role`, `form_name`, `source=marketing_website`, `marketing_opt_in`                       | Ne contient aucune donnée d'identité.                                                       |
+| Erreur formulaire    | `form_submit_error`        | `funnel_name=pre_signup`, `funnel_step=submit_error`, `role`, `form_name`, `source=marketing_website`, `error_type`, `field` si validation client | `error_type=client_validation` ou `api_or_network`.                                         |
+| Consentement accepté | `cookie_consent_updated`   | `status=accepted`                                                                                                                                 | Les refus ne sont pas trackés avant consentement.                                           |
+
+## Actions PostHog créées
+
+- `UG - Pre-signup CTA Click`
+- `UG - Pre-signup Role Selected`
+- `UG - Pre-signup Submit Attempt`
+- `UG - Pre-signup Submit Success`
+- `UG - Pre-signup Submit Error`
+- `UG - Analytics Consent Accepted`
+
+## Funnels à maintenir
+
+- Particulier : `page_view` marketing → CTA pré-inscription → choix `role=user` → tentative `role=user` → succès `role=user`.
+- Professionnel : `page_view` marketing → CTA pré-inscription → choix `role=provider` → tentative `role=provider` → succès `role=provider`.
+
+La première étape n'est pas limitée à `/pre-inscription`, car les CTA de conversion partent principalement de `/client`, `/pro` et du header. Les pages d'entrée se lisent via `entry_path`, `current_path` et les propriétés UTM.
+
+Segments prioritaires :
+
+- `role`
+- `form_name`
+- `cta`
+- `location`
+- `entry_path`
+- `current_path`
+- `traffic_source`
+- `utm_source`, `utm_medium`, `utm_campaign`
+- navigateur, appareil et OS via propriétés automatiques PostHog.

--- a/pre_inscription_and_back_office_tasks.md
+++ b/pre_inscription_and_back_office_tasks.md
@@ -32,16 +32,18 @@ Constat MCP du 8 juillet 2026 : le projet est accessible et a reçu des événem
 
 Prérequis : le lot 1 est mergé et les événements sont visibles dans PostHog.
 
-- [ ] Documenter la taxonomie des événements et propriétés non sensibles.
-- [ ] Ajouter ou mettre à jour les actions PostHog pour : choix du profil, tentative, succès et erreur.
-- [ ] Remplacer l'ancien funnel `pageview → CTA → contact` par les funnels :
-  - [ ] `pageview → CTA pré-inscription → choix du profil → tentative → succès` pour les particuliers ;
-  - [ ] le même funnel pour les professionnels.
-- [ ] Ajouter les taux d'erreur par profil et type d'erreur.
-- [ ] Ajouter la conversion par page d'entrée, CTA, source UTM, appareil et navigateur.
-- [ ] Ajouter un suivi du consentement accepté sans tenter de mesurer les refus avant consentement.
-- [ ] Mettre à jour les dashboards `UG - Marketing Conversion` et `UG - Engagement & Trust`.
-- [ ] Vérifier que chaque insight retourne des données cohérentes.
+- [x] Documenter la taxonomie des événements et propriétés non sensibles.
+- [x] Ajouter ou mettre à jour les actions PostHog pour : CTA, choix du profil, tentative, succès et erreur.
+- [x] Remplacer l'ancien funnel `pageview → CTA → contact` par les funnels :
+  - [x] `pageview → CTA pré-inscription → choix du profil → tentative → succès` pour les particuliers ;
+  - [x] le même funnel pour les professionnels.
+- [x] Ajouter les taux d'erreur par profil et type d'erreur.
+- [x] Ajouter la conversion par page d'entrée, CTA, source UTM, appareil et navigateur.
+- [x] Ajouter un suivi du consentement accepté sans tenter de mesurer les refus avant consentement.
+- [x] Mettre à jour les dashboards `UG - Marketing Conversion` et `UG - Engagement & Trust`.
+- [ ] Vérifier que chaque insight retourne des données cohérentes après réception de trafic réel.
+
+Constat MCP du 8 juillet 2026 : les actions PostHog et les insights du funnel sont créés, mais les nouveaux événements/propriétés ne sont pas encore présents dans la taxonomie ingérée. Les requêtes sont valides et se rempliront après déploiement et trafic avec consentement accepté.
 
 ## Lot 3 — Valider la pré-inscription de bout en bout
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -52,13 +52,22 @@ export function Header() {
                     : 'rounded-full px-3 py-1.5 hover:bg-[var(--ug-surface)] hover:text-[var(--ug-text)]'
                 }}
                 key={item.to}
-                onClick={() =>
+                onClick={() => {
                   trackEvent('nav_click', {
                     label: item.label,
                     location: 'header',
                     to: item.to,
                   })
-                }
+                  if (item.to === '/pre-inscription') {
+                    trackEvent('cta_click', {
+                      cta: 'header_pre_signup',
+                      funnel_name: 'pre_signup',
+                      funnel_step: 'cta_click',
+                      location: 'header',
+                      to: item.to,
+                    })
+                  }
+                }}
                 to={item.to}
               >
                 {item.label}

--- a/src/components/pre-signup/PreSignupForm.test.tsx
+++ b/src/components/pre-signup/PreSignupForm.test.tsx
@@ -75,8 +75,11 @@ describe('PreSignupForm critical flow', () => {
     await waitFor(() => {
       expect(trackEventMock).toHaveBeenCalledWith('form_submit', {
         form_name: 'pre_signup_client',
+        funnel_name: 'pre_signup',
+        funnel_step: 'submit_success',
         marketing_opt_in: false,
         role: 'user',
+        source: 'marketing_website',
       })
     })
   })

--- a/src/components/pre-signup/PreSignupForm.tsx
+++ b/src/components/pre-signup/PreSignupForm.tsx
@@ -125,7 +125,10 @@ export function PreSignupForm({
 
     trackEvent('form_submit_attempt', {
       form_name: trackingFormName,
+      funnel_name: 'pre_signup',
+      funnel_step: 'submit_attempt',
       role,
+      source: 'marketing_website',
     })
 
     if (!firstName || !lastName) {
@@ -133,7 +136,10 @@ export function PreSignupForm({
         error_type: 'client_validation',
         field: 'identity',
         form_name: trackingFormName,
+        funnel_name: 'pre_signup',
+        funnel_step: 'submit_error',
         role,
+        source: 'marketing_website',
       })
       setLocalError('Le prenom et le nom sont obligatoires.')
       return
@@ -144,7 +150,10 @@ export function PreSignupForm({
         error_type: 'client_validation',
         field: 'provider_display_name',
         form_name: trackingFormName,
+        funnel_name: 'pre_signup',
+        funnel_step: 'submit_error',
         role,
+        source: 'marketing_website',
       })
       setLocalError('Le nom public est obligatoire pour un prestataire.')
       return
@@ -189,8 +198,11 @@ export function PreSignupForm({
       })
       trackEvent('form_submit', {
         form_name: trackingFormName,
+        funnel_name: 'pre_signup',
+        funnel_step: 'submit_success',
         marketing_opt_in: marketingOptIn,
         role,
+        source: 'marketing_website',
       })
       form.reset()
       setSuccessMessage('Pre-inscription envoyee avec succes.')
@@ -198,7 +210,10 @@ export function PreSignupForm({
       trackEvent('form_submit_error', {
         error_type: 'api_or_network',
         form_name: trackingFormName,
+        funnel_name: 'pre_signup',
+        funnel_step: 'submit_error',
         role,
+        source: 'marketing_website',
       })
       setSuccessMessage(null)
     }

--- a/src/lib/analytics.consent.test.ts
+++ b/src/lib/analytics.consent.test.ts
@@ -12,6 +12,7 @@ vi.mock('posthog-js', () => ({
 
 import {
   ANALYTICS_CONSENT_STORAGE_KEY,
+  getAnalyticsContextProperties,
   setAnalyticsConsentStatus,
   trackEvent,
   trackPageView,
@@ -46,6 +47,8 @@ describe('analytics consent gating', () => {
     })
 
     captureMock.mockReset()
+    window.sessionStorage.clear()
+    window.history.replaceState({}, '', '/')
   })
 
   it('scenario 1: does not send analytics without consent', () => {
@@ -116,5 +119,53 @@ describe('analytics consent gating', () => {
     }
 
     expect(filter?.(event)).toBeNull()
+  })
+
+  it('adds non-sensitive attribution context to accepted events', () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/pre-inscription?utm_source=instagram&utm_medium=social&utm_campaign=launch'
+    )
+    setAnalyticsConsentStatus('accepted')
+
+    trackEvent('pre_signup_role_selected', {
+      funnel_name: 'pre_signup',
+      role: 'user',
+    })
+
+    expect(captureMock).toHaveBeenCalledWith(
+      'pre_signup_role_selected',
+      expect.objectContaining({
+        current_path: '/pre-inscription',
+        entry_path: '/pre-inscription',
+        funnel_name: 'pre_signup',
+        traffic_source: 'instagram',
+        utm_campaign: 'launch',
+        utm_medium: 'social',
+        utm_source: 'instagram',
+      })
+    )
+  })
+
+  it('keeps first-touch attribution during the same session', () => {
+    window.history.replaceState({}, '', '/?utm_source=tiktok')
+    expect(getAnalyticsContextProperties()).toEqual(
+      expect.objectContaining({
+        entry_path: '/',
+        traffic_source: 'tiktok',
+        utm_source: 'tiktok',
+      })
+    )
+
+    window.history.replaceState({}, '', '/pre-inscription')
+    expect(getAnalyticsContextProperties()).toEqual(
+      expect.objectContaining({
+        current_path: '/pre-inscription',
+        entry_path: '/',
+        traffic_source: 'tiktok',
+        utm_source: 'tiktok',
+      })
+    )
   })
 })

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -23,6 +23,17 @@ export const posthogOptions: Partial<PostHogConfig> = {
 export const ANALYTICS_CONSENT_STORAGE_KEY = 'ug_cookie_consent'
 export const ANALYTICS_CONSENT_CHANGED_EVENT = 'ug-cookie-consent-changed'
 export const COOKIE_PREFERENCES_OPEN_EVENT = 'ug-cookie-preferences-open'
+const ANALYTICS_ATTRIBUTION_STORAGE_KEY = 'ug_marketing_attribution'
+const UTM_KEYS = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+] as const
+
+type AnalyticsPropertyValue = string | number | boolean | null | undefined
+type AnalyticsProperties = Record<string, AnalyticsPropertyValue>
 
 export type AnalyticsConsentStatus = 'accepted' | 'refused'
 
@@ -69,20 +80,84 @@ export function openCookiePreferences() {
   window.dispatchEvent(new Event(COOKIE_PREFERENCES_OPEN_EVENT))
 }
 
-export function trackEvent(
-  event: AnalyticsEventName,
-  properties?: Record<string, string | number | boolean | null | undefined>
-) {
-  if (!hasAnalyticsConsent()) return
+function readStoredAttribution(): AnalyticsProperties {
+  try {
+    const stored = window.sessionStorage.getItem(
+      ANALYTICS_ATTRIBUTION_STORAGE_KEY
+    )
 
-  posthog.capture(event, properties)
+    return stored ? JSON.parse(stored) : {}
+  } catch {
+    return {}
+  }
 }
 
-export function trackPageView(
-  properties: Record<string, string | number | boolean | null | undefined>
+function writeStoredAttribution(properties: AnalyticsProperties) {
+  try {
+    window.sessionStorage.setItem(
+      ANALYTICS_ATTRIBUTION_STORAGE_KEY,
+      JSON.stringify(properties)
+    )
+  } catch {
+    // Ignore storage failures to avoid breaking the user journey.
+  }
+}
+
+export function getAnalyticsContextProperties(): AnalyticsProperties {
+  if (typeof window === 'undefined') return {}
+
+  const url = new URL(window.location.href)
+  const storedAttribution = readStoredAttribution()
+  const urlAttribution = UTM_KEYS.reduce<AnalyticsProperties>((acc, key) => {
+    const value = url.searchParams.get(key)
+    if (value) acc[key] = value
+
+    return acc
+  }, {})
+  const hasFreshUtm = Object.keys(urlAttribution).length > 0
+  const attribution: AnalyticsProperties = {
+    ...storedAttribution,
+    ...urlAttribution,
+    entry_path: storedAttribution.entry_path ?? url.pathname,
+    entry_search: storedAttribution.entry_search ?? url.search,
+    initial_referrer:
+      storedAttribution.initial_referrer ?? document.referrer ?? '',
+  }
+
+  if (hasFreshUtm || !storedAttribution.entry_path) {
+    writeStoredAttribution(attribution)
+  }
+
+  return {
+    ...attribution,
+    current_path: url.pathname,
+    current_search: url.search,
+    current_url: url.href,
+    referrer: document.referrer ?? '',
+    traffic_source: attribution.utm_source ?? 'direct',
+  }
+}
+
+export function trackEvent(
+  event: AnalyticsEventName,
+  properties?: AnalyticsProperties
 ) {
   if (!hasAnalyticsConsent()) return
 
-  posthog.capture('$pageview', properties)
-  trackEvent('page_view', properties)
+  posthog.capture(event, {
+    ...getAnalyticsContextProperties(),
+    ...properties,
+  })
+}
+
+export function trackPageView(properties: AnalyticsProperties) {
+  if (!hasAnalyticsConsent()) return
+
+  const pageViewProperties = {
+    ...getAnalyticsContextProperties(),
+    ...properties,
+  }
+
+  posthog.capture('$pageview', pageViewProperties)
+  posthog.capture('page_view', pageViewProperties)
 }

--- a/src/pages/Client.tsx
+++ b/src/pages/Client.tsx
@@ -55,7 +55,10 @@ export function ClientPage() {
               onClick={() =>
                 trackEvent('cta_click', {
                   cta: 'client_signup',
+                  funnel_name: 'pre_signup',
+                  funnel_step: 'cta_click',
                   location: 'client_page',
+                  target_role: 'user',
                   to: '/pre-inscription',
                 })
               }

--- a/src/pages/PreSignup.tsx
+++ b/src/pages/PreSignup.tsx
@@ -28,7 +28,12 @@ export function PreSignupPage() {
 
   const selectRole = (nextRole: PreSignupRole) => {
     setRole(nextRole)
-    trackEvent('pre_signup_role_selected', { role: nextRole })
+    trackEvent('pre_signup_role_selected', {
+      form_name: roleConfig[nextRole].trackingFormName,
+      funnel_name: 'pre_signup',
+      funnel_step: 'role_selected',
+      role: nextRole,
+    })
   }
 
   return (

--- a/src/pages/Pro.tsx
+++ b/src/pages/Pro.tsx
@@ -55,7 +55,10 @@ export function ProPage() {
               onClick={() =>
                 trackEvent('cta_click', {
                   cta: 'pro_signup',
+                  funnel_name: 'pre_signup',
+                  funnel_step: 'cta_click',
                   location: 'pro_page',
+                  target_role: 'provider',
                   to: '/pre-inscription',
                 })
               }


### PR DESCRIPTION
## Summary

Couvre le funnel de pré-inscription dans PostHog et dans le tracking frontend.

- enrichit tous les événements analytics avec contexte de page, attribution first-touch et UTM non sensibles ;
- ajoute les propriétés de funnel sur les CTA, choix de profil, tentatives, succès et erreurs de pré-inscription ;
- documente la taxonomie PostHog dans `docs/posthog-pre-signup-taxonomy.md` ;
- met à jour le plan de livraison du Lot 2.

Côté PostHog MCP, les actions et insights ont été créés dans le projet `130601` : funnels client/pro, erreurs par rôle/type, conversion par source/CTA, engagement hebdomadaire et action consentement accepté.

## Checklist

- [x] PR title follows semantic convention (`feat:`, `fix:`, `chore:`, etc.)
- [x] Source branch name follows `type/description` (example: `fix/login-error-message`)
- [ ] `npm run workflow:check` passes locally
- [x] UX impact has been tested on mobile if UI changed
- [ ] Screenshots or short video added for UI changes

## Validation

- [x] `npm run test` — 8 files, 19 tests passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] Prettier targeted check on modified files

`npm run workflow:check` still does not pass locally because the global `format:check` reports pre-existing formatting issues outside this Lot 2 scope. The modified files pass targeted Prettier. The cleanup is tracked separately in Lot 6.

## PostHog objects created

Actions:

- `UG - Pre-signup CTA Click` — `143068`
- `UG - Pre-signup Role Selected` — `143069`
- `UG - Pre-signup Submit Attempt` — `143070`
- `UG - Pre-signup Submit Success` — `143071`
- `UG - Pre-signup Submit Error` — `143073`
- `UG - Analytics Consent Accepted` — `143076`

Insights:

- `UG - Pre-signup Funnel - Client` — `voPiodp3`
- `UG - Pre-signup Funnel - Pro` — `3KwYsKZu`
- `UG - Pre-signup Errors by Role and Type` — `9J5qZebf`
- `UG - Pre-signup Conversion by Source and CTA` — `Lcgcww82`
- `UG - Pre-signup Weekly Engagement` — `JbY18mUp`

Note: the new events/properties are not yet present in the ingested PostHog taxonomy. Queries are valid but will return meaningful data only after deployment and real traffic with accepted analytics consent.

## Related

- Issue: #
